### PR TITLE
Quick PoC: Decrease num of lattice API call by resourcegroupstaggingapi.GetResource()

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -41,10 +41,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gwv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
-	"github.com/aws/aws-application-networking-k8s/controllers/eventhandlers"
-	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	pkg_builder "sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/aws/aws-application-networking-k8s/controllers/eventhandlers"
+	"github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 )
 
 const (
@@ -211,7 +212,7 @@ func (r *gatewayReconciler) reconcileUpsert(ctx context.Context, gw *gwv1beta1.G
 	snInfo, err := r.cloud.Lattice().FindServiceNetwork(ctx, gw.Name, config.AccountID)
 	if err != nil {
 		if services.IsNotFoundError(err) {
-			if err = r.updateGatewayProgrammedStatus(ctx, *snInfo.SvcNetwork.Arn, gw, false); err != nil {
+			if err = r.updateGatewayProgrammedStatus(ctx, "", gw, false); err != nil {
 				return err
 			}
 			return nil

--- a/examples/inventory-ver1.yaml
+++ b/examples/inventory-ver1.yaml
@@ -1,35 +1,35 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: inventory-ver1
+  name: inventory-1
   labels:
-    app: inventory-ver1
+    app: inventory-1
 spec:
   replicas: 2
   selector:
     matchLabels:
-      app: inventory-ver1
+      app: inventory-1
   template:
     metadata:
       labels:
-        app: inventory-ver1
+        app: inventory-1
     spec:
       containers:
-      - name: inventory-ver1
+      - name: inventory-1
         image: public.ecr.aws/x2j8p8w7/http-server:latest
         env:
         - name: PodName
-          value: "Inventory-ver1 handler pod"
+          value: "inventory-1 handler pod"
 
 
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: inventory-ver1
+  name: inventory-1
 spec:
   selector:
-    app: inventory-ver1
+    app: inventory-1
   ports:
     - protocol: TCP
       port: 80

--- a/pkg/deploy/lattice/target_group_manager_test.go
+++ b/pkg/deploy/lattice/target_group_manager_test.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/vpclattice"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
 	pkg_aws "github.com/aws/aws-application-networking-k8s/pkg/aws"
 	mocks "github.com/aws/aws-application-networking-k8s/pkg/aws/services"
 	"github.com/aws/aws-application-networking-k8s/pkg/config"
 	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
 	model "github.com/aws/aws-application-networking-k8s/pkg/model/lattice"
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/service/vpclattice"
-	"github.com/golang/mock/gomock"
-	"github.com/stretchr/testify/assert"
-	"reflect"
-	"testing"
 )
 
 // target group does not exist, and is active after creation

--- a/pkg/deploy/lattice/target_group_synthesizer.go
+++ b/pkg/deploy/lattice/target_group_synthesizer.go
@@ -12,7 +12,6 @@ import (
 
 	anv1alpha1 "github.com/aws/aws-application-networking-k8s/pkg/apis/applicationnetworking/v1alpha1"
 	"github.com/aws/aws-application-networking-k8s/pkg/gateway"
-
 	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -344,9 +343,9 @@ func (t *TargetGroupSynthesizer) shouldDeleteRouteTg(
 		return true // safe to delete
 	}
 
-	// here we just delete anything more than X minutes old - worst case we'll have to recreate
+	// here we just delete anything more than X hours old - worst case we'll have to recreate
 	// the target group - note this case is only theoretically possible at this point
-	fiveMinsAgo := time.Now().Add(-time.Minute * 5)
+	fiveMinsAgo := time.Now().Add(-time.Hour * 5)
 	if fiveMinsAgo.After(aws.TimeValue(latticeTg.getTargetGroupOutput.CreatedAt)) {
 		t.log.Debugf("Will delete TargetGroup %s (%s) - TG is more than 5 minutes old",
 			*latticeTg.getTargetGroupOutput.Arn, *latticeTg.getTargetGroupOutput.Name)

--- a/pkg/deploy/lattice/target_group_synthesizer_test.go
+++ b/pkg/deploy/lattice/target_group_synthesizer_test.go
@@ -2,20 +2,22 @@ package lattice
 
 import (
 	"context"
-	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
-	"github.com/aws/aws-application-networking-k8s/pkg/config"
-	"github.com/aws/aws-application-networking-k8s/pkg/gateway"
-	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
-	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
+	"net/http"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/vpclattice"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
-	"time"
+
+	mock_client "github.com/aws/aws-application-networking-k8s/mocks/controller-runtime/client"
+	"github.com/aws/aws-application-networking-k8s/pkg/config"
+	"github.com/aws/aws-application-networking-k8s/pkg/gateway"
+	"github.com/aws/aws-application-networking-k8s/pkg/model/core"
+	"github.com/aws/aws-application-networking-k8s/pkg/utils/gwlog"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
10 routes spend 3 min
100 routes spend 33 min


Graphs for 100 routes testing: 

The GetResource() and the rest of ListTagsForResource() are no longer the top time consumers: 
![image](https://github.com/solmonk/aws-application-networking-k8s/assets/32318664/ce4a8c59-9ecd-4552-a215-019e401b8d03)
![image](https://github.com/solmonk/aws-application-networking-k8s/assets/32318664/05494feb-24a4-45bd-8d94-3410f6f9e930)

For the Optimized version, RegisterTargets spent the most time, I think because of the throttling?
![image](https://github.com/solmonk/aws-application-networking-k8s/assets/32318664/d9bd4905-290e-4a15-a0b1-89b7999621cf)



One strange thing is seems only after 100 targetGroup creation ALL finished then the controller start to createService, need to figure out why it cannot run as pipelines
![image](https://github.com/solmonk/aws-application-networking-k8s/assets/32318664/910a72fd-f5bc-45b9-9fae-71d39927da97)

